### PR TITLE
Version 1.0.3

### DIFF
--- a/badgeos-learndash.php
+++ b/badgeos-learndash.php
@@ -5,7 +5,7 @@
  * Description: This BadgeOS add-on integrates BadgeOS features with LearnDash
  * Tags: learndash
  * Author: LearningTimes, LLC
- * Version: 1.0.2
+ * Version: 1.0.3
  * Author URI: http://www.learningtimes.com/
  * License: GNU AGPLv3
  * License URI: http://www.gnu.org/licenses/agpl-3.0.html

--- a/includes/rules-engine.php
+++ b/includes/rules-engine.php
@@ -180,7 +180,7 @@ function badgeos_learndash_user_deserves_learndash_step( $return, $user_id, $ach
 		}
 
 		// Use basic trigger logic if no object set
-		if ( empty( $object_id ) ) {
+        if ( empty( $object_id ) && !in_array( $learndash_trigger, $learndash_category_triggers ) ) {
 			$learndash_triggered = true;
 		}
 		// Object specific
@@ -191,7 +191,7 @@ function badgeos_learndash_user_deserves_learndash_step( $return, $user_id, $ach
 			$requirements[ 'count' ] = 1;
 		}
 		// Category specific
-		elseif ( in_array( $learndash_trigger, $learndash_category_triggers ) && has_term( $object_id, 'post_tag', $triggered_object_id ) ) {
+        elseif ( in_array( $learndash_trigger, $learndash_category_triggers ) && has_term( $object_id, 'ld_course_tag', $triggered_object_id ) ) {
 			$learndash_triggered = true;
 
 			// Forcing count due to BadgeOS bug tracking triggers properly

--- a/includes/steps-ui.php
+++ b/includes/steps-ui.php
@@ -198,7 +198,7 @@ function badgeos_learndash_step_etc_select( $step_id, $post_id ) {
 	echo '<option value="">' . __( 'Any Course Tag', 'badgeos-learndash' ) . '</option>';
 
 	// Loop through all objects
-	$objects = get_terms( 'post_tag', array(
+	$objects = get_terms( 'ld_course_tag', array(
 		'hide_empty' => false
 	) );
 
@@ -320,7 +320,7 @@ function badgeos_learndash_save_step( $title, $step_id, $step_data ) {
 				$title = __( 'Completed course in any tag', 'badgeos-learndash' );
 			}
 			else {
-				$title = sprintf( __( 'Completed course in tag "%s"', 'badgeos-learndash' ), get_term( $object_id, 'post_tag' )->name );
+				$title = sprintf( __( 'Completed course in tag "%s"', 'badgeos-learndash' ), get_term( $object_id, 'ld_course_tag' )->name );
 			}
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: badgeos, learningtimes
 Donate link: http://badgeos.org/contribute/donate/
 Tags: learndash, badge, badges, openbadges, learningtimes, OBI, mozilla, open badges, achievement, award, reward, engagement, submission, nomination, API, open credit, credit
-Requires at least: WordPress 3.5 & BadgeOS 1.2
-Tested up to: 4.5.3
-Stable tag: 1.0.2
+Requires at least: WordPress 4.0 & BadgeOS 1.4.11 or higher
+Tested up to: 4.9.8
+Stable tag: 1.0.3
 License: GNU AGPLv3
 License URI: http://www.gnu.org/licenses/agpl-3.0.html
 
@@ -45,6 +45,7 @@ In addition to all of the out-of-the-box features in BadgeOS core, the BadgeOS L
    *   Achieve a minimum percent grade on a specific Quiz
    *   Achieve a minimum percent grade on any Quiz
    *   Fail a Quiz (i.e. useful for rewarding the passing of a previously failed quiz)
+   *   Fail a specific Quiz
 
 **Combine LearnDash Steps with BadgeOS Steps in Defining Achievements**
 
@@ -130,6 +131,10 @@ Thanks for asking!  Please do share back code modifications or enhancements you 
 
 
 == Changelog ==
+
+= 1.0.3 =
+* Fixed: badges was not awarding on completing course from specific tag.
+* Fixed: Made the plugin compatible with latest version of wordpress 4.9.8 and PHP version 7.2
 
 = 1.0.2 =
 * Fixed: Issues changing the amount of times a step must be completed for non-LearnDash activities.


### PR DESCRIPTION
- Fixed: badges was not awarding on completing course from specific tag.
- Fixed: Made the plugin compatible with latest version of wordpress 4.9.8 and PHP version 7.2